### PR TITLE
Use Transform API for MpegTsDemuxer

### DIFF
--- a/packages/mpegts-demuxer/src/__test__/MpegTsDemuxer.test.ts
+++ b/packages/mpegts-demuxer/src/__test__/MpegTsDemuxer.test.ts
@@ -2,7 +2,7 @@ import { MpegTsDemuxer } from '..'
 
 describe('MpegTsDemuxer', () => {
 	it('should be a constructor', () => {
-		const demuxer = new MpegTsDemuxer(() => {})
+		const demuxer = new MpegTsDemuxer()
 		expect(demuxer).toBeInstanceOf(MpegTsDemuxer)
 	})
 })


### PR DESCRIPTION
## Description
This PR replaces the old `callback` pattern with the shiny [`Transform Stream`](
https://nodejs.org/api/stream.html#stream_class_stream_transform) pattern

MpegTsDemuxer should now be treated as a Duplex stream -- it can be used as part of a pipeline.

## Related Issues
Resolves #7
