### PR TITLE
Prevent overflows

### DIFF
--- a/packages/mpegts-demuxer/CHANGELOG.md
+++ b/packages/mpegts-demuxer/CHANGELOG.md
@@ -12,3 +12,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - The package is now much more compliant with our linting rules.
 - Large PTS and DTS values no longer result in int overflows.
+- MpegTsDemuxer now adheres to the Transform Stream API.

--- a/packages/mpegts-demuxer/CHANGELOG.md
+++ b/packages/mpegts-demuxer/CHANGELOG.md
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - The package is now much more compliant with our linting rules.
+- Large PTS and DTS values no longer result in int overflows.

--- a/packages/mpegts-demuxer/src/utils/__test__/bitwiseOperators.test.ts
+++ b/packages/mpegts-demuxer/src/utils/__test__/bitwiseOperators.test.ts
@@ -1,0 +1,32 @@
+import {
+	leftShift,
+	rightShift,
+	bitMask,
+} from '../bitwiseOperators'
+
+describe('leftShift', () => {
+	it('should shift left', () => {
+		expect(leftShift(0b0010, 1))
+			.toBe(0b0100)
+		expect(leftShift(0b0010, 2))
+			.toBe(0b1000)
+		expect(leftShift(0b0110, 2))
+			.toBe(0b11000)
+	})
+})
+describe('rightShift', () => {
+	it('should shift bits to the right', () => {
+		expect(rightShift(0b0010, 1))
+			.toBe(0b0001)
+		expect(rightShift(0b0010, 2))
+			.toBe(0b0000)
+		expect(rightShift(0b1010, 1))
+			.toBe(0b0101)
+	})
+})
+describe('bitMask', () => {
+	it('should mask bits', () => {
+		expect(bitMask(0b1111, 0b1010))
+			.toBe(0b1010)
+	})
+})

--- a/packages/mpegts-demuxer/src/utils/__test__/index.test.ts
+++ b/packages/mpegts-demuxer/src/utils/__test__/index.test.ts
@@ -1,0 +1,42 @@
+import {
+	decodeTs,
+} from '..'
+
+describe('decodeTs', () => {
+	it('should decode timestamps that use multiple bytes', () => {
+		const chunk = new Uint8Array([
+			0b00000000,
+			0b00000100,
+			0b00010000,
+			0b00100000,
+			0b00001010,
+		])
+		const mem = new DataView(chunk.buffer)
+		const decodedTimestamp = decodeTs(mem, 0)
+		expect(decodedTimestamp).toBe(17043461) // 0b00000001000001000001000000000101
+	})
+	it('should decode small timestamps', () => {
+		const chunk = new Uint8Array([
+			0b00000000,
+			0b00000000,
+			0b00000000,
+			0b00000000,
+			0b00001010,
+		])
+		const mem = new DataView(chunk.buffer)
+		const decodedTimestamp = decodeTs(mem, 0)
+		expect(decodedTimestamp).toBe(5) // 0b101
+	})
+	it('should timestamps larger than 32 bit integers', () => {
+		const chunk = new Uint8Array([
+			0b11111111,
+			0b11111111,
+			0b11111111,
+			0b11111111,
+			0b11111111,
+		])
+		const mem = new DataView(chunk.buffer)
+		const decodedTimestamp = decodeTs(mem, 0)
+		expect(decodedTimestamp).toBe(8589934591)
+	})
+})

--- a/packages/mpegts-demuxer/src/utils/bitwiseOperators.ts
+++ b/packages/mpegts-demuxer/src/utils/bitwiseOperators.ts
@@ -1,0 +1,13 @@
+export function leftShift(x: number, amount: number): number {
+	return x * 2 ** amount
+}
+
+export function rightShift(x: number, amount: number): number {
+	return Math.trunc(x / 2 ** amount)
+}
+
+// This is one of those rare applications where we actually need bitwise operators
+// as I don't know if there is a great way to do a bit mask without using `&`
+/* eslint-disable no-bitwise */
+export function bitMask(x: number, mask: number): number { return x & mask }
+/* eslint-enable no-bitwise */

--- a/packages/mpegts-demuxer/src/utils/index.ts
+++ b/packages/mpegts-demuxer/src/utils/index.ts
@@ -6,6 +6,12 @@
 // Changing this is a goal, but will be a heavy lift.
 /* eslint-disable no-param-reassign */
 
+import {
+	leftShift,
+	rightShift,
+	bitMask,
+} from './bitwiseOperators'
+
 import type {
 	Pmt,
 	Packet,
@@ -72,11 +78,18 @@ export function getMediaType(type_id: number): number {
 }
 
 export function decodeTs(mem: DataView, p: number): number {
-	return ((mem.getUint8(p) & 0xe) << 29)
-				| ((mem.getUint8(p + 1) & 0xff) << 22)
-				| ((mem.getUint8(p + 2) & 0xfe) << 14)
-				| ((mem.getUint8(p + 3) & 0xff) << 7)
-				| ((mem.getUint8(p + 4) & 0xfe) >> 1)
+	const pieces = [
+		bitMask(mem.getUint8(p), 0b00001110),
+		bitMask(mem.getUint8(p + 1), 0b11111111),
+		bitMask(mem.getUint8(p + 2), 0b11111110),
+		bitMask(mem.getUint8(p + 3), 0b11111111),
+		bitMask(mem.getUint8(p + 4), 0b11111110),
+	]
+	return leftShift(pieces[0], 29)
+		+ leftShift(pieces[1], 22)
+		+ leftShift(pieces[2], 14)
+		+ leftShift(pieces[3], 7)
+		+ rightShift(pieces[4], 1)
 }
 
 export function decodePat(


### PR DESCRIPTION
## Description
This PR fixes an issue where large timestamps (over 2^32) would result in integer overflows.

## Related Issues
Resolves #12 