### PR TITLE
Rename package

### DIFF
--- a/packages/mpegts-demuxer/CHANGELOG.md
+++ b/packages/mpegts-demuxer/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Changelog for @tvkitchen/mpegts-demuxer
+# Changelog for mpegts-demuxer
 
 All notable changes to this project will be documented in this file.
 

--- a/packages/mpegts-demuxer/README.md
+++ b/packages/mpegts-demuxer/README.md
@@ -4,6 +4,22 @@ This package demuxes packets from an [MPEG transport stream](https://en.wikipedi
 
 It is a modified fork of the excellent [TSDemuxer package](https://github.com/gliese1337/HLS.js/tree/master/demuxer) created by [Logan Kearsley](https://github.com/gliese1337).  The overall project was started as a JavaScript / TypeScript implementation of [Anton Burdinuk's C++ MPEG-TS demuxer](https://github.com/clark15b/tsdemuxer/blob/67a20b47dd4a11282134ee61d390cc64d1083e61/v1.0/tsdemux.cpp).
 
+## How to Use
+
+The `MpegTsDemuxer` is a NodeJS [`Transform` stream](https://nodejs.org/api/stream.html#stream_class_stream_transform) which means it supports the Read and Write stream APIs.  It consumes raw mpegts data as a stream and emits [Packet](src/classes/Packet.ts) objects as they are parsed.
+
+```
+import { MpegTsDemuxer } from 'mpegts-demuxer'
+import { createReadStream } from 'fs'
+
+const fileStream = fs.createReadStream('myFile.ts')
+const mpegTsDemuxer = new MpegTsDemuxer()
+fileStream.pipe(mpegTsDemuxer)
+mpegTsDemuxer.on('data', (packet) => {
+	console.log(packet)
+})
+```
+
 ## References
 
 If you want to understand the technical specifications related to demuxing MPEG-TS streams can [check out the spec directly](http://ecee.colorado.edu/~ecen5653/ecen5653/papers/iso13818-1.pdf).

--- a/packages/mpegts-demuxer/package.json
+++ b/packages/mpegts-demuxer/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@tvkitchen/mpegts-demuxer",
+  "name": "mpegts-demuxer",
   "description": "Extracts packets from an MPEG transport stream.",
   "version": "0.0.0",
   "repository": {


### PR DESCRIPTION
## Description
This PR renames the `mpegts-demuxer` utility and adds some documentation on use.

We should be able to publish a first version from here.

## Related Issues
Related to #1
