### PR TITLE
Allow pts rollover

### DIFF
--- a/packages/mpegts-demuxer/CHANGELOG.md
+++ b/packages/mpegts-demuxer/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- PTS is now allowed to decrease between packets, allowing support for timestamp rollovers.
 
 ## [0.1.0] - 2021-05-13
 ### Added

--- a/packages/mpegts-demuxer/src/utils/index.ts
+++ b/packages/mpegts-demuxer/src/utils/index.ts
@@ -290,7 +290,7 @@ function decodePes(
 					const pts = decodeTs(mem, ptr + 3)
 
 					if (s.has_dts && pts !== s.dts) { s.frame_ticks = pts - s.dts }
-					if (pts > s.last_pts || !s.has_pts) { s.last_pts = pts }
+					s.last_pts = pts
 
 					if (s.first_pts === 0
 						&& s.frame_num === (s.content_type === MEDIA_TYPES.video ? 1 : 0)) {
@@ -308,7 +308,7 @@ function decodePes(
 					const dts = decodeTs(mem, ptr + 8)
 
 					if (s.has_dts && dts > s.dts) { s.frame_ticks = dts - s.dts }
-					if (pts > s.last_pts || !s.has_pts) { s.last_pts = pts }
+					s.last_pts = pts
 
 					if (s.first_pts === 0
 						&& s.frame_num === (s.content_type === MEDIA_TYPES.video ? 1 : 0)) {


### PR DESCRIPTION
## Description
This PR removes logic that prevented `pts` from ever decreasing.  This means that when `pts` rolls over during a very long stream the demuxer will reflect the new pts.  It is the responsibility of the consuming code to handle this event.

## Related Issues
Resolves #18 
